### PR TITLE
Fix row scan type for RenotifyAll.

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -584,10 +584,6 @@ func (st *storage) Notify(change hkpstorage.KeyChange) error {
 }
 
 func (st *storage) RenotifyAll() error {
-	var result struct {
-		MD5 string `bson:"md5"`
-	}
-
 	sqlStr := fmt.Sprintf("SELECT md5 FROM keys")
 	rows, err := st.Query(sqlStr)
 	if err != nil {
@@ -596,7 +592,8 @@ func (st *storage) RenotifyAll() error {
 
 	defer rows.Close()
 	for rows.Next() {
-		err := rows.Scan(&result)
+		var md5 string
+		err := rows.Scan(&md5)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return nil
@@ -604,7 +601,7 @@ func (st *storage) RenotifyAll() error {
 				return errgo.Mask(err)
 			}
 		}
-		st.Notify(hkpstorage.KeyAdded{Digest: result.MD5})
+		st.Notify(hkpstorage.KeyAdded{Digest: md5})
 	}
 	err = rows.Err()
 	return errgo.Mask(err)


### PR DESCRIPTION
This fixes an error in `hockeypuck-pbuild`, caused by binding the wrong type (copypasta from the mgo driver, I'm afraid) in the row scan.

```
ubuntu@hkp:~/hkp/gopath/src/github.com/hockeypuck/server/cmd/hockeypuck-pbuild$ ./hockeypuck-pbuild -config ~/hkp.conf 
WARN[0000] error executing "ALTER TABLE keys ADD CONSTRAINT keys_pk PRIMARY KEY (rfingerprint);": pq: multiple primary keys for table "keys" are not allowed 
WARN[0000] error executing "ALTER TABLE keys ADD CONSTRAINT keys_md5 UNIQUE (md5);": pq: relation "keys_md5" already exists 
WARN[0000] error executing "CREATE INDEX keys_rfp ON keys(rfingerprint text_pattern_ops);": pq: relation "keys_rfp" already exists 
WARN[0000] error executing "CREATE INDEX keys_ctime ON keys (ctime);": pq: relation "keys_ctime" already exists 
WARN[0000] error executing "CREATE INDEX keys_mtime ON keys (mtime);": pq: relation "keys_mtime" already exists 
WARN[0000] error executing "CREATE INDEX keys_keywords ON keys USING gin(keywords);": pq: relation "keys_keywords" already exists 
WARN[0000] error executing "ALTER TABLE subkeys ADD CONSTRAINT subkeys_pk PRIMARY KEY (rsubfp);": pq: multiple primary keys for table "subkeys" are not allowed 
WARN[0000] error executing "ALTER TABLE subkeys ADD CONSTRAINT subkeys_fk FOREIGN KEY (rfingerprint) REFERENCES keys(rfingerprint);": pq: constraint "subkeys_fk" for relation "subkeys" already exists 
WARN[0000] error executing "CREATE INDEX subkeys_rfp ON subkeys(rsubfp text_pattern_ops);": pq: relation "subkeys_rfp" already exists 
[{/home/ubuntu/hkp/gopath/src/github.com/hockeypuck/server/cmd/hockeypuck-pbuild/main.go:103: } {/home/ubuntu/hkp/gopath/src/gopkg.in/hockeypuck/pghkp.v1/storage.go:604: } {sql: Scan error on column index 0: unsupported driver -> Scan pair: []uint8 -> *struct { MD5 string "bson:\"md5\"" }}]
```
