### PR TITLE
Match username or domain part of email addresses

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -534,7 +534,15 @@ func keywords(key *openpgp.PrimaryKey) []string {
 		s := strings.ToLower(uid.Keywords)
 		lbr, rbr := strings.Index(s, "<"), strings.LastIndex(s, ">")
 		if lbr != -1 && rbr > lbr {
-			m[s[lbr+1:rbr]] = true
+			email := s[lbr+1 : rbr]
+			m[email] = true
+
+			parts := strings.SplitN(email, "@", 2)
+			if len(parts) > 1 {
+				username, domain := parts[0], parts[1]
+				m[username] = true
+				m[domain] = true
+			}
 		}
 		if lbr != -1 {
 			fields := strings.FieldsFunc(s[:lbr], func(r rune) bool {

--- a/storage_test.go
+++ b/storage_test.go
@@ -177,9 +177,10 @@ func (s *S) TestResolve(c *gc.C) {
 		// subkeys
 		"0xdb769d16cdb9ad53", "0xe9ebaf4195c1826c", "0x6cdc23d76cba8ca9",
 
-		// contiguous words and email addresses match
+		// contiguous words, usernames, domains and email addresses match
 		"casey", "marshall", "marshal", "casey+marshall", "cAseY+MArSHaLL",
-		"casey.marshall@gmail.com", "casey.marshall@gazzang.com"} {
+		"casey.marshall@gmail.com", "casey.marshall@gazzang.com",
+		"casey.marshall", "gmail.com"} {
 		comment := gc.Commentf("search=%s", search)
 		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
 		c.Assert(err, gc.IsNil, comment)


### PR DESCRIPTION
Users want to search for keys for a particular username, like “prz”. Or they want to search for keys for a domain, like “pgp.com”.

Postgres’ `to_tsarray` does not split across the `@`-sign, so email addresses are indexed as a whole lexeme. This is great to find “prz@pgp.com” but not good for the above use-cases.

`keywords` now recognizes an email address and splits across the first `@`-sign it encounters to find the username and domain.

Contributed by @Quantcast: https://quantcast.com